### PR TITLE
Use the power of PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,13 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "Ns3777k\\PrometheusBundle\\": "src/Ns3777k/PrometheusBundle/"
-        },
-        "exclude-from-classmap": [
-            "**/Tests/"
-        ]
+            "Ns3777k\\PrometheusBundle\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Ns3777k\\PrometheusBundle\\Tests\\": "tests/"
+        }
     },
     "authors": [
         {


### PR DESCRIPTION
This PR is not ready to be merged. One should do this first: 

```
mkdir tests
mv src/Ns3777k/PrometheusBundle/Tests/* tests/
mv src/Ns3777k/PrometheusBundle/* src/
```

The difference between PSR-0 and PSR-4 is basically that we get rid of this deep directory tree. 

I will not finish this PR, I created it just to show an example. Feel free to finish it yourself or to close it. 